### PR TITLE
Add qnote to Notes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ Some great GitHub repos with wallpaper collections by:
 
 - [AppFlowy](https://github.com/AppFlowy-IO/AppFlowy) - AI collaborative workspace where you achieve more without losing control of your data.
 - [Obsidian](https://obsidian.md/) - Personal knowledge base and note-taking software application that operates on Markdown files.
+- [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with Markdown preview, real PDF export via Typst, OCR via Tesseract, and automatic version history. Built with Tauri 2. Available on AUR.
 
 
 ### Workstation - Content Creation


### PR DESCRIPTION
**qnote** is a minimal frameless notepad for Linux built with Tauri 2 (Rust + TypeScript).

Key features:
- Markdown preview with live split view
- Real PDF export via Typst (proper typesetting, not HTML-to-PDF)
- OCR via Tesseract
- Automatic version history with configurable intervals
- Dark/light themes, custom fonts
- Available on AUR

GitHub: https://github.com/Omibranch/qnote
License: MIT