### PR TITLE
readme: redirect to Codeberg repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Some great GitHub repos with wallpaper collections by:
 - [gboncoffee](https://github.com/gboncoffee/wallpapers)
 - [zDyanTB](https://github.com/zDyanTB/aesthetic-wallpapers)
 - [vctrblck](https://github.com/vctrblck/gruvbox-wallpapers)<sup>Gruvbox</sup>
-- [jorgeloopzz](https://github.com/jorgeloopzz/Wallpapers)
+- [jorgeloopzz](https://codeberg.org/jorgeloopzz/Wallpapers)
 - [Axenide](https://github.com/Axenide/Wallpapers)
 - [er2de2](https://github.com/er2de2/catppuccin_walls)<sup>Catppuccin</sup>
 


### PR DESCRIPTION
I just realized my old Github wallpapers repo appears on this project, but few months ago I moved to Codeberg, then I fixed the URL :)